### PR TITLE
fix: strip line break in message validity check

### DIFF
--- a/nostr/relay.py
+++ b/nostr/relay.py
@@ -80,6 +80,7 @@ class Relay:
         pass
 
     def _is_valid_message(self, message: str) -> bool:
+        message = message.strip("\n")
         if not message or message[0] != '[' or message[-1] != ']':
             return False
 


### PR DESCRIPTION
(some?) relays send event message with a  traliing line break. I needed to strip it to make sure that the incoming messages were valid.