### PR TITLE
[Feature] Initial NIP-26 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,38 @@ while relay_manager.message_pool.has_events():
 relay_manager.close_connections()
 ```
 
+**NIP-26 delegation**
+```python
+from nostr.delegation import Delegation
+from nostr.event import EventKind, Event
+from nostr.key import PrivateKey
+
+# Load your "identity" PK that you'd like to keep safely offline
+identity_pk = PrivateKey.from_nsec("nsec1...")
+
+# Create a new, disposable PK as the "delegatee" that can be "hot" in a Nostr client
+delegatee_pk = PrivateKey()
+
+# the "identity" PK will authorize "delegatee" to sign TEXT_NOTEs on its behalf for the next month
+delegation = Delegation(
+    delegator_pubkey=identity_pk.public_key.hex(),
+    delegatee_pubkey=delegatee_pk.public_key.hex(),
+    event_kind=EventKind.TEXT_NOTE,
+    duration_secs=30*24*60
+)
+
+identity_pk.sign_delegation(delegation)
+
+event = Event(
+    delegatee_pk.public_key.hex(),
+    "Hello, NIP-26!",
+    tags=[delegation.get_tag()],
+)
+event.sign(delegatee_pk.hex())
+
+# ...normal broadcast steps...
+```
+
 ## Installation
 ```bash
 pip install nostr

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ delegation = Delegation(
     delegator_pubkey=identity_pk.public_key.hex(),
     delegatee_pubkey=delegatee_pk.public_key.hex(),
     event_kind=EventKind.TEXT_NOTE,
-    duration_secs=30*24*60
+    duration_secs=30*24*60*60
 )
 
 identity_pk.sign_delegation(delegation)

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ event.sign(delegatee_pk.hex())
 # ...normal broadcast steps...
 ```
 
+The resulting delegation tag can be stored as plaintext and reused as-is by the "delegatee" PK until the delegation token expires. There is no way to revoke a signed delegation, so current best practice is to keep the expiration time relatively short.
+
+Hopefully clients will include an optional field to store the delegation tag. That would allow the "delegatee" PK to seamlessly post messages on the "identity" key's behalf, while the "identity" key stays safely offline in cold storage.
+
+
 ## Installation
 ```bash
 pip install nostr

--- a/nostr/delegation.py
+++ b/nostr/delegation.py
@@ -1,0 +1,32 @@
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class Delegation:
+    delegator_pubkey: str
+    delegatee_pubkey: str
+    event_kind: int
+    duration_secs: int = 30*24*60  # default to 30 days
+    signature: str = None  # set in PrivateKey.sign_delegation
+
+    @property
+    def expires(self) -> int:
+        return int(time.time()) + self.duration_secs
+    
+    @property
+    def conditions(self) -> str:
+        return f"kind={self.event_kind}&created_at<{self.expires}"
+    
+    @property
+    def delegation_token(self) -> str:
+        return f"nostr:delegation:{self.delegatee_pubkey}:{self.conditions}"
+
+    def get_tag(self) -> list[str]:
+        """ Called by Event """
+        return [
+            "delegation",
+            self.delegator_pubkey,
+            self.conditions,
+            self.signature,
+        ]

--- a/nostr/event.py
+++ b/nostr/event.py
@@ -4,6 +4,7 @@ from enum import IntEnum
 from secp256k1 import PrivateKey, PublicKey
 from hashlib import sha256
 
+
 class EventKind(IntEnum):
     SET_METADATA = 0
     TEXT_NOTE = 1
@@ -11,6 +12,7 @@ class EventKind(IntEnum):
     CONTACTS = 3
     ENCRYPTED_DIRECT_MESSAGE = 4
     DELETE = 5
+
 
 class Event():
     def __init__(

--- a/nostr/key.py
+++ b/nostr/key.py
@@ -4,7 +4,11 @@ import secp256k1
 from cffi import FFI
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives import padding
+from hashlib import sha256
+
+from nostr.delegation import Delegation
 from . import bech32
+
 
 class PublicKey:
     def __init__(self, raw_bytes: bytes) -> None:
@@ -93,6 +97,9 @@ class PrivateKey:
         sk = secp256k1.PrivateKey(self.raw_secret)
         sig = sk.schnorr_sign(hash, None, raw=True)
         return sig.hex()
+    
+    def sign_delegation(self, delegation: Delegation) -> None:
+        delegation.signature = self.sign_message_hash(sha256(delegation.delegation_token.encode()).digest())
 
     def __eq__(self, other):
         return self.raw_secret == other.raw_secret


### PR DESCRIPTION
Implements [NIP-26](https://github.com/nostr-protocol/nips/blob/master/26.md)

An "identity" key (the delegator) can authorize a "delegatee" key to sign messages on behalf of the "identity" key.

```
delegation = Delegation(
    delegator_pubkey=identity_pk.public_key.hex(),
    delegatee_pubkey=delegatee_pk.public_key.hex(),
    event_kind=EventKind.TEXT_NOTE,
    duration_secs=30*24*60*60
)

identity_pk.sign_delegation(delegation)

event = Event(
    delegatee_pk.public_key.hex(),
    "Hello, NIP-26!",
    tags=[delegation.get_tag()],
)
event.sign(delegatee_pk.hex())
```

---

### Coding philosophy note
I intentionally avoided doing any signing within the `Delegation` class and instead designed it to be passed into a `PrivateKey` instance. The PK is hot either way, but it just feels wrong to pass the PK's secret around and manually do the signing in other objects (`Event`, I'm looking at you!).

---

My initial test seems correct but isn't rendering right in Nostr clients:
[`@note1xepm0lvkc6xp3ppn22fd8506elx4y8mrufqf7tgq7m8xrsfz2f4smr0v06`](https://snort.social/e/note1xepm0lvkc6xp3ppn22fd8506elx4y8mrufqf7tgq7m8xrsfz2f4smr0v06)
