### PR TITLE
cleaning up created_at default test

### DIFF
--- a/test/test_event.py
+++ b/test/test_event.py
@@ -3,8 +3,9 @@ from nostr.key import PrivateKey
 import time
 
 def test_event_default_time():
-    """ensure created_at default value reflects the time
-    at Event object instantiation 
+    """
+        ensure created_at default value reflects the time at Event object instantiation
+        see: https://github.com/jeffthibault/python-nostr/issues/23
     """
     public_key = PrivateKey().public_key.hex()
     event1 = Event(public_key=public_key, content='test event')

--- a/test/test_event.py
+++ b/test/test_event.py
@@ -3,7 +3,11 @@ from nostr.key import PrivateKey
 import time
 
 def test_event_default_time():
-    time.sleep(1.5)
+    """ensure created_at default value reflects the time
+    at Event object instantiation 
+    """
     public_key = PrivateKey().public_key.hex()
-    event = Event(public_key=public_key, content='test event')
-    assert (event.created_at - time.time()) < 1
+    event1 = Event(public_key=public_key, content='test event')
+    time.sleep(1.5)
+    event2 = Event(public_key=public_key, content='test event')
+    assert event1.created_at != event2.created_at

--- a/test/test_event.py
+++ b/test/test_event.py
@@ -11,4 +11,4 @@ def test_event_default_time():
     event1 = Event(public_key=public_key, content='test event')
     time.sleep(1.5)
     event2 = Event(public_key=public_key, content='test event')
-    assert event1.created_at != event2.created_at
+    assert event1.created_at < event2.created_at


### PR DESCRIPTION
This is an update to PR #24 as was discussed there. Adding comment to clarify the purpose and changing the logic to compare time stamps of two events with a delay in-between. How does this look, @kdmukai? Anything else you would add/clarify?