### PR TITLE
Fix subscription bug in add_relay

### DIFF
--- a/nostr/relay_manager.py
+++ b/nostr/relay_manager.py
@@ -19,7 +19,8 @@ class RelayManager:
         self.relays: dict[str, Relay] = {}
         self.message_pool = MessagePool()
 
-    def add_relay(self, url: str, read: bool=True, write: bool=True, subscriptions={}):
+    def add_relay(self, url: str, read: bool=True, write: bool=True, subscriptions: dict=None):
+        subscriptions = subscriptions or {}
         policy = RelayPolicy(read, write)
         relay = Relay(url, policy, self.message_pool, subscriptions)
         self.relays[url] = relay

--- a/test/test_relay_manager.py
+++ b/test/test_relay_manager.py
@@ -1,6 +1,7 @@
 import pytest
 from nostr.event import Event
 from nostr.key import PrivateKey
+from nostr.subscription import Subscription
 from nostr.relay_manager import RelayManager, RelayException
 
 
@@ -28,3 +29,22 @@ def test_only_relay_valid_events():
     # Properly signed Event can be relayed
     pk.sign_event(event)
     relay_manager.publish_event(event)
+
+
+def test_separate_subscriptions():
+    """
+        make sure that subscription dictionary default is not the same object
+        across all relays so that subscriptions can vary
+    """
+    # initiate relay manager with two relays
+    relay_manager = RelayManager()
+    relay_manager.add_relay(url='fake-relay1')
+    relay_manager.add_relay(url='fake-relay2')
+
+    # make test subscription and add to one relay
+    test_subscription = Subscription(id='test')
+    relay_manager.relays['fake-relay1'].subscriptions.update(
+        {test_subscription.id: test_subscription}
+    )
+    # make sure test subscription isn't in second relay subscriptions
+    assert test_subscription.id not in relay_manager.relays['fake-relay2'].subscriptions.keys()


### PR DESCRIPTION
This PR moves the default dictionary object for subscriptions out of the default argument and into the body of the method. 

Currently the subscription dictionary is a single shared object across all relays (and even across relay managers). An update on one relay will update will update all relays and even newly created relays will have the same subscriptions. This change will make it so each relay actually has it's own subscription dictionary. It will also make it so a new RelayManager object wont have subscriptions linked to an old one. I've also added a test in `test_relay_manager.py` that shows this behavior