### PR TITLE
Subscription tests and automatically coerce subscription id to string

### DIFF
--- a/nostr/subscription.py
+++ b/nostr/subscription.py
@@ -2,7 +2,7 @@ from .filter import Filters
 
 class Subscription:
     def __init__(self, id: str, filters: Filters=None) -> None:
-        self.id = id
+        self.id = str(id)
         self.filters = filters
 
     def to_json_object(self):

--- a/nostr/subscription.py
+++ b/nostr/subscription.py
@@ -1,7 +1,7 @@
 from .filter import Filters
 
 class Subscription:
-    def __init__(self, id: str, filters: Filters=None) -> None:
+    def __init__(self, id: str, filters: Filters) -> None:
         self.id = str(id)
         self.filters = filters
 

--- a/test/test_subscription.py
+++ b/test/test_subscription.py
@@ -1,0 +1,15 @@
+import json
+from nostr.filter import Filter, Filters
+from nostr.message_type import ClientMessageType
+from nostr.subscription import Subscription
+
+def test_subscription_id():
+    subscription = Subscription(id=123, filters=Filters([Filter()]))
+    request = [ClientMessageType.REQUEST, subscription.id]
+    request.extend(subscription.filters.to_json_array())
+    message = json.dumps(request)
+    request_received = json.loads(message)
+    message_type, subscription_id, req_filters = request_received
+    assert isinstance(subscription_id, str)
+    assert message_type == ClientMessageType.REQUEST
+    assert isinstance(req_filters, dict)

--- a/test/test_subscription.py
+++ b/test/test_subscription.py
@@ -3,7 +3,12 @@ from nostr.filter import Filter, Filters
 from nostr.message_type import ClientMessageType
 from nostr.subscription import Subscription
 
+
 def test_subscription_id():
+    """
+        check that subscription contents dump to JSON and load
+        back to Python with expected types
+    """
     subscription = Subscription(id=123, filters=Filters([Filter()]))
     request = [ClientMessageType.REQUEST, subscription.id]
     request.extend(subscription.filters.to_json_array())


### PR DESCRIPTION
Adding a test that makes sure content in the subscription class is consistent with expected types when converted to json and back. Notably, the current class doesn't force the id to be a string.

I've also removed the default `filters` value of `None` since it is currently unused in the body of the function and isn't a valid option for a subscription - maybe it makes sense to replace this with an empty `Filters` object instead?