### PR TITLE
Mining refactor with new features

### DIFF
--- a/nostr/key.py
+++ b/nostr/key.py
@@ -108,28 +108,6 @@ class PrivateKey:
     def __eq__(self, other):
         return self.raw_secret == other.raw_secret
 
-def mine_vanity_key(prefix: str = None, suffix: str = None) -> PrivateKey:
-    if prefix is None and suffix is None:
-        raise ValueError("Expected at least one of 'prefix' or 'suffix' arguments")
-
-    bech32_chars = '023456789acdefghjklmnpqrstuvwxyz'
-    for pattern in [prefix, suffix]:
-        if pattern is not None:
-            missing_chars = [c for c in pattern if c not in bech32_chars]
-            if len(missing_chars):
-                raise ValueError(
-                    f'{missing_chars} are not valid characters'
-                    f'for a bech32 key. Valid characters include ({bech32_chars})')
-
-    while True:
-        sk = PrivateKey()
-        if prefix is not None and not sk.public_key.bech32()[5:5+len(prefix)] == prefix:
-            continue
-        if suffix is not None and not sk.public_key.bech32()[-len(suffix):] == suffix:
-            continue
-        break
-
-    return sk
 
 ffi = FFI()
 @ffi.callback("int (unsigned char *, const unsigned char *, const unsigned char *, void *)")

--- a/nostr/key.py
+++ b/nostr/key.py
@@ -112,6 +112,15 @@ def mine_vanity_key(prefix: str = None, suffix: str = None) -> PrivateKey:
     if prefix is None and suffix is None:
         raise ValueError("Expected at least one of 'prefix' or 'suffix' arguments")
 
+    bech32_chars = '023456789acdefghjklmnpqrstuvwxyz'
+    for pattern in [prefix, suffix]:
+        if pattern is not None:
+            missing_chars = [c for c in pattern if c not in bech32_chars]
+            if len(missing_chars):
+                raise ValueError(
+                    f'{missing_chars} are not valid characters'
+                    f'for a bech32 key. Valid characters include ({bech32_chars})')
+
     while True:
         sk = PrivateKey()
         if prefix is not None and not sk.public_key.bech32()[5:5+len(prefix)] == prefix:

--- a/nostr/pow.py
+++ b/nostr/pow.py
@@ -52,3 +52,27 @@ def mine_key(difficulty: int) -> PrivateKey:
         num_leading_zero_bits = count_leading_zero_bits(sk.public_key.hex())
 
     return sk
+
+
+def mine_vanity_key(prefix: str = None, suffix: str = None) -> PrivateKey:
+    if prefix is None and suffix is None:
+        raise ValueError("Expected at least one of 'prefix' or 'suffix' arguments")
+
+    bech32_chars = '023456789acdefghjklmnpqrstuvwxyz'
+    for pattern in [prefix, suffix]:
+        if pattern is not None:
+            missing_chars = [c for c in pattern if c not in bech32_chars]
+            if len(missing_chars):
+                raise ValueError(
+                    f'{missing_chars} are not valid characters'
+                    f'for a bech32 key. Valid characters include ({bech32_chars})')
+
+    while True:
+        sk = PrivateKey()
+        if prefix is not None and not sk.public_key.bech32()[5:5+len(prefix)] == prefix:
+            continue
+        if suffix is not None and not sk.public_key.bech32()[-len(suffix):] == suffix:
+            continue
+        break
+
+    return sk

--- a/nostr/pow.py
+++ b/nostr/pow.py
@@ -78,10 +78,10 @@ def mine_vanity_key(prefix: str = None, suffix: str = None) -> PrivateKey:
     for pattern in [prefix, suffix]:
         if pattern is not None:
             missing_chars = [c for c in pattern if c not in bech32_chars]
-            if len(missing_chars):
+            if len(missing_chars) > 0:
                 raise ValueError(
-                    f'{missing_chars} are not valid characters'
-                    f'for a bech32 key. Valid characters include ({bech32_chars})')
+                    f"{missing_chars} not in valid list of bech32 chars: ({bech32_chars})"
+                    )
     while True:
         sk, vk = _guess_vanity_key()
         if prefix is not None and not vk[5:5+len(prefix)] == prefix:

--- a/test/test_key.py
+++ b/test/test_key.py
@@ -1,5 +1,5 @@
 import pytest
-from nostr.key import PrivateKey, mine_vanity_key
+from nostr.key import PrivateKey
 
 
 def test_eq_true():
@@ -22,21 +22,3 @@ def test_from_nsec():
     pk1 = PrivateKey()
     pk2 = PrivateKey.from_nsec(pk1.bech32())
     assert pk1.raw_secret == pk2.raw_secret
-
-
-def test_mine_vanity_key():
-    """ test vanity key mining """
-    pattern = '23'
-
-    # mine a valid pattern as prefix
-    sk = mine_vanity_key(prefix=pattern)
-    sk.public_key.bech32()
-    assert sk.public_key.bech32().startswith(f'npub1{pattern}')
-
-    # mine a valid pattern as suffix
-    sk = mine_vanity_key(suffix=pattern)
-    assert sk.public_key.bech32().endswith(pattern)
-
-    # mine an invalid pattern
-    with pytest.raises(ValueError) as e:
-        mine_vanity_key(prefix='1')

--- a/test/test_key.py
+++ b/test/test_key.py
@@ -1,4 +1,5 @@
-from nostr.key import PrivateKey
+import pytest
+from nostr.key import PrivateKey, mine_vanity_key
 
 
 def test_eq_true():
@@ -21,3 +22,21 @@ def test_from_nsec():
     pk1 = PrivateKey()
     pk2 = PrivateKey.from_nsec(pk1.bech32())
     assert pk1.raw_secret == pk2.raw_secret
+
+
+def test_mine_vanity_key():
+    """ test vanity key mining """
+    pattern = '23'
+
+    # mine a valid pattern as prefix
+    sk = mine_vanity_key(prefix=pattern)
+    sk.public_key.bech32()
+    assert sk.public_key.bech32().startswith(f'npub1{pattern}')
+
+    # mine a valid pattern as suffix
+    sk = mine_vanity_key(suffix=pattern)
+    assert sk.public_key.bech32().endswith(pattern)
+
+    # mine an invalid pattern
+    with pytest.raises(ValueError) as e:
+        mine_vanity_key(prefix='1')

--- a/test/test_pow.py
+++ b/test/test_pow.py
@@ -47,8 +47,11 @@ def test_mine_vanity_key():
     assert sk.public_key.bech32().endswith(pattern)
 
     # mine an invalid pattern
+    pattern = '1'
+    expected_error = "not in valid list of bech32 chars"
     with pytest.raises(ValueError) as e:
-        mine_vanity_key(prefix='1')
+        sk = mine_vanity_key(prefix=pattern)
+    assert expected_error in str(e)
 
 
 def test_expected_pow_times():

--- a/test/test_pow.py
+++ b/test/test_pow.py
@@ -20,6 +20,19 @@ def test_mine_key():
     assert pow.count_leading_zero_bits(sk.public_key.hex()) >= difficulty
 
 
+def test_time_estimates():
+    """ test functions to estimate POW time """
+    public_key = PrivateKey().public_key.hex()
+
+    # test successful run of all estimators
+    pow.estimate_event_time('test',
+                            8,
+                            public_key,
+                            EventKind.TEXT_NOTE)
+    pow.estimate_key_time(8)
+    pow.estimate_vanity_time(8)
+
+
 def test_mine_vanity_key():
     """ test vanity key mining """
     pattern = '23'
@@ -36,3 +49,16 @@ def test_mine_vanity_key():
     # mine an invalid pattern
     with pytest.raises(ValueError) as e:
         mine_vanity_key(prefix='1')
+
+
+def test_expected_pow_times():
+    """ sense check expected calculations using known patterns """
+    # assume constant hashrate
+    hashrate = 10000
+
+    # calculate expected time to get a 32-difficulty bit key
+    e1 = pow.expected_time(32, 2, hashrate)
+
+    # caluclate 8 leading 0 hex key, which is equivalent
+    e2 = pow.expected_time(8, 16, hashrate)
+    assert e1 == e2

--- a/test/test_pow.py
+++ b/test/test_pow.py
@@ -1,0 +1,38 @@
+import pytest
+from nostr.key import PrivateKey
+from nostr.event import EventKind
+from nostr import pow
+from nostr.pow import mine_event, mine_key, mine_vanity_key
+
+def test_mine_event():
+    """ test mining an event with specific difficulty """
+    public_key = PrivateKey().public_key.hex()
+    difficulty = 8
+    event = mine_event(content='test',difficulty=difficulty,
+                       public_key=public_key, kind=EventKind.TEXT_NOTE)
+    assert pow.count_leading_zero_bits(event.id) >= difficulty
+
+
+def test_mine_key():
+    """ test mining a public key with specific difficulty """
+    difficulty = 8
+    sk = mine_key(difficulty)
+    assert pow.count_leading_zero_bits(sk.public_key.hex()) >= difficulty
+
+
+def test_mine_vanity_key():
+    """ test vanity key mining """
+    pattern = '23'
+
+    # mine a valid pattern as prefix
+    sk = mine_vanity_key(prefix=pattern)
+    sk.public_key.bech32()
+    assert sk.public_key.bech32().startswith(f'npub1{pattern}')
+
+    # mine a valid pattern as suffix
+    sk = mine_vanity_key(suffix=pattern)
+    assert sk.public_key.bech32().endswith(pattern)
+
+    # mine an invalid pattern
+    with pytest.raises(ValueError) as e:
+        mine_vanity_key(prefix='1')


### PR DESCRIPTION
This is a rather large PR that I fully expect to be reworked, but wanted to share because I think it adds some useful features. I've tried to break the commits up into logical steps so we can choose to only appy a subset if needed.

 - raise error if vanity characters not in bech32 possible characters
 - move `mine_vanity_key` into POW to avoid circular imports when adding other features
 - refactor functions that make "guesses" out of the mining functions so that we can use them to test performance
 - add methods to check hashrate and estimate mining times for both types of private key mining and event mining