### PR TITLE
Track connection state and reconnect on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ print(f"Public key: {public_key.bech32()}")
 ```
 **Connect to relays**
 ```python
+import json
+import ssl
 import time
 from nostr.relay_manager import RelayManager
 
@@ -30,6 +32,8 @@ relay_manager.close_connections()
 ```
 **Publish to relays**
 ```python
+import json 
+import ssl
 import time
 from nostr.event import Event
 from nostr.relay_manager import RelayManager
@@ -55,6 +59,8 @@ relay_manager.close_connections()
 ```
 **Receive events from relays**
 ```python
+import json
+import ssl
 import time
 from nostr.filter import Filter, Filters
 from nostr.event import Event, EventKind

--- a/main.py
+++ b/main.py
@@ -1,0 +1,80 @@
+from nostr.client.client import NostrClient
+from nostr.event import Event
+from nostr.key import PublicKey
+import asyncio
+import threading
+
+
+async def dm():
+    print("This is an example NIP-04 DM flow")
+    pk = input("Enter your privatekey to post from (enter nothing for a random one): ")
+
+    def callback(event: Event, decrypted_content):
+        """
+        Callback to trigger when a DM is received.
+        """
+        print(
+            f"From {event.public_key[:3]}..{event.public_key[-3:]}: {decrypted_content}"
+        )
+
+    client = NostrClient(privatekey_hex=pk)
+    await asyncio.sleep(1)
+
+    t = threading.Thread(
+        target=client.get_dm,
+        args=(
+            client.public_key,
+            callback,
+        ),
+    )
+    t.start()
+
+    to_pubk_hex = (
+        input("Enter other pubkey to post to (enter nothing to DM yourself): ")
+        or client.public_key.hex()
+    )
+    print(f"Subscribing to DMs to {to_pubk_hex}")
+    while True:
+        msg = input("\nEnter message: ")
+        client.dm(msg, PublicKey(bytes.fromhex(to_pubk_hex)))
+
+
+async def post():
+    print("This posts and reads a nostr note")
+    pk = input("Enter your privatekey to post from (enter nothing for a random one): ")
+
+    def callback(event: Event):
+        """
+        Callback to trigger when post appers.
+        """
+        print(f"From {event.public_key[:3]}..{event.public_key[-3:]}: {event.content}")
+
+    sender_client = NostrClient(privatekey_hex=pk)
+    await asyncio.sleep(1)
+
+    to_pubk_hex = (
+        input("Enter other pubkey (enter nothing to read your own posts): ")
+        or sender_client.public_key.hex()
+    )
+    print(f"Subscribing to posts by {to_pubk_hex}")
+    to_pubk = PublicKey(bytes.fromhex(to_pubk_hex))
+
+    t = threading.Thread(
+        target=sender_client.get_post,
+        args=(
+            to_pubk,
+            callback,
+        ),
+    )
+    t.start()
+
+    while True:
+        msg = input("\nEnter post: ")
+        sender_client.post(msg)
+
+
+# write a DM and receive DMs
+asyncio.run(dm())
+
+# make a post and subscribe to posts
+# asyncio.run(post())

--- a/nostr/client/cbc.py
+++ b/nostr/client/cbc.py
@@ -1,0 +1,41 @@
+
+from Cryptodome import Random
+from Cryptodome.Cipher import AES
+
+plain_text = "This is the text to encrypts"
+
+# encrypted = "7mH9jq3K9xNfWqIyu9gNpUz8qBvGwsrDJ+ACExdV1DvGgY8q39dkxVKeXD7LWCDrPnoD/ZFHJMRMis8v9lwHfNgJut8EVTMuJJi8oTgJevOBXl+E+bJPwej9hY3k20rgCQistNRtGHUzdWyOv7S1tg==".encode()
+# iv = "GzDzqOVShWu3Pl2313FBpQ==".encode()
+
+key = bytes.fromhex("3aa925cb69eb613e2928f8a18279c78b1dca04541dfd064df2eda66b59880795")
+
+BLOCK_SIZE = 16
+
+class AESCipher(object):
+    """This class is compatible with crypto.createCipheriv('aes-256-cbc')
+
+    """
+    def __init__(self, key=None):
+        self.key = key
+
+    def pad(self, data):
+        length = BLOCK_SIZE - (len(data) % BLOCK_SIZE)
+        return data + (chr(length) * length).encode()
+
+    def unpad(self, data):
+        return data[: -(data[-1] if type(data[-1]) == int else ord(data[-1]))]
+
+    def encrypt(self, plain_text):
+        cipher = AES.new(self.key, AES.MODE_CBC)
+        b = plain_text.encode("UTF-8")
+        return cipher.iv, cipher.encrypt(self.pad(b))
+
+    def decrypt(self, iv, enc_text):
+        cipher = AES.new(self.key, AES.MODE_CBC, iv=iv)
+        return self.unpad(cipher.decrypt(enc_text).decode("UTF-8"))
+        
+if __name__ == "__main__":
+    aes = AESCipher(key=key)
+    iv, enc_text = aes.encrypt(plain_text)
+    dec_text = aes.decrypt(iv, enc_text)
+    print(dec_text)

--- a/nostr/client/client.py
+++ b/nostr/client/client.py
@@ -48,10 +48,10 @@ class NostrClient:
         pk = bytes.fromhex(privatekey_hex) if privatekey_hex else None
         self.private_key = PrivateKey(pk)
         self.public_key = self.private_key.public_key
-        print(
-            f"Nostr private key: {self.private_key.hex()} ({self.private_key.bech32()})"
-        )
-        print(f"Nostr public key: {self.public_key.hex()} ({self.public_key.bech32()})")
+        # print(
+        #     f"Nostr private key: {self.private_key.hex()} ({self.private_key.bech32()})"
+        # )
+        # print(f"Nostr public key: {self.public_key.hex()} ({self.public_key.bech32()})")
 
     def post(self, message: str):
         event = Event(self.public_key.hex(), message, kind=EventKind.TEXT_NOTE)

--- a/nostr/client/client.py
+++ b/nostr/client/client.py
@@ -1,0 +1,165 @@
+from typing import *
+import ssl
+import time
+import json
+import os
+import base64 
+
+from nostr.event import Event
+from nostr.relay_manager import RelayManager
+from nostr.message_type import ClientMessageType
+from nostr.key import PrivateKey, PublicKey
+
+from nostr.filter import Filter, Filters
+from nostr.event import Event, EventKind
+from nostr.relay_manager import RelayManager
+from nostr.message_type import ClientMessageType
+
+# from aes import AESCipher
+from . import cbc
+
+
+class NostrClient:
+    relays = [
+        # "wss://nostr-pub.wellorder.net"
+        "wss://nostr.zebedee.cloud",
+        # "wss://nodestr.fmt.wiz.biz/",
+        # "wss://no.str.cr",
+    ]  # ["wss://nostr.oxtr.dev"]  # ["wss://relay.nostr.info"] "wss://nostr-pub.wellorder.net"  "ws://91.237.88.218:2700", "wss://nostrrr.bublina.eu.org", ""wss://nostr-relay.freeberty.net"", , "wss://nostr.oxtr.dev", "wss://relay.nostr.info", "wss://nostr-pub.wellorder.net" , "wss://relayer.fiatjaf.com", "wss://nodestr.fmt.wiz.biz/", "wss://no.str.cr"
+    relay_manager = RelayManager()
+    private_key: PrivateKey
+    public_key: PublicKey
+
+    def __init__(self, privatekey_hex: str = "", relays: List[str] = []):
+        self.generate_keys(privatekey_hex)
+
+        if len(relays):
+            self.relays = relays
+
+        for relay in self.relays:
+            self.relay_manager.add_relay(relay)
+        self.relay_manager.open_connections(
+            {"cert_reqs": ssl.CERT_NONE}
+        )  # NOTE: This disables ssl certificate verification
+
+    def close(self):
+        self.relay_manager.close_connections()
+
+    def generate_keys(self, privatekey_hex: str = None):
+        pk = bytes.fromhex(privatekey_hex) if privatekey_hex else None
+        self.private_key = PrivateKey(pk)
+        self.public_key = self.private_key.public_key
+        print(f"Private key: {self.private_key.bech32()} ({self.private_key.hex()})")
+        print(f"Public key: {self.public_key.bech32()} ({self.public_key.hex()})")
+
+    def post(self, message: str):
+        event = Event(self.public_key.hex(), message, kind=EventKind.TEXT_NOTE)
+        event.sign(self.private_key.hex())
+        message = json.dumps([ClientMessageType.EVENT, event.to_json_object()])
+        # print("Publishing message:")
+        # print(message)
+        self.relay_manager.publish_message(message)
+
+    def get_post(self, sender_publickey: PublicKey, callback_func=None):
+        filters = Filters(
+            [Filter(authors=[sender_publickey.hex()], kinds=[EventKind.TEXT_NOTE])]
+        )
+        subscription_id = os.urandom(4).hex()
+        self.relay_manager.add_subscription(subscription_id, filters)
+
+        request = [ClientMessageType.REQUEST, subscription_id]
+        request.extend(filters.to_json_array())
+        message = json.dumps(request)
+        # print("Subscribing to events:")
+        # print(message)
+        self.relay_manager.publish_message(message)
+
+        while True:
+            while self.relay_manager.message_pool.has_events():
+                event_msg = self.relay_manager.message_pool.get_event()
+                print(event_msg.event.content)
+                if callback_func:
+                    callback_func(event_msg.event)
+            time.sleep(0.1)
+
+    def dm(self, message: str, to_pubkey: PublicKey):
+
+        shared_secret = self.private_key.compute_shared_secret(
+            to_pubkey.hex()
+        )
+
+        # print("shared secret: ", shared_secret.hex())
+        # print("plain text:", message)
+        aes = cbc.AESCipher(key=shared_secret)
+        iv, enc_text = aes.encrypt(message)
+        # print("encrypt iv: ", iv)
+        content = f"{base64.b64encode(enc_text).decode('utf-8')}?iv={base64.b64encode(iv).decode('utf-8')}"
+
+
+        event = Event(
+            self.public_key.hex(),
+            content,
+            tags=[["p", to_pubkey.hex()]],
+            kind=EventKind.ENCRYPTED_DIRECT_MESSAGE,
+        )
+        event.sign(self.private_key.hex())
+        event_message = json.dumps([ClientMessageType.EVENT, event.to_json_object()])
+        # print("DM message:")
+        # print(event_message)
+
+        time.sleep(1)
+        self.relay_manager.publish_message(event_message)
+
+    def get_dm(self, sender_publickey: PublicKey, callback_func=None):
+        filters = Filters(
+            [
+                Filter(
+                    kinds=[EventKind.ENCRYPTED_DIRECT_MESSAGE],
+                    tags={"#p": [sender_publickey.hex()]},
+                )
+            ]
+        )
+        subscription_id = os.urandom(4).hex()
+        self.relay_manager.add_subscription(subscription_id, filters)
+
+        request = [ClientMessageType.REQUEST, subscription_id]
+        request.extend(filters.to_json_array())
+        message = json.dumps(request)
+        # print("Subscribing to events:")
+        # print(message)
+        self.relay_manager.publish_message(message)
+
+        while True:
+            while self.relay_manager.message_pool.has_events():
+                event_msg = self.relay_manager.message_pool.get_event()
+                if "?iv=" in event_msg.event.content:
+                    try:
+                        shared_secret = self.private_key.compute_shared_secret(
+                            event_msg.event.public_key
+                        )
+                        # print("shared secret: ", shared_secret.hex())
+                        # print("plain text:", message)
+                        aes = cbc.AESCipher(key=shared_secret)
+                        enc_text_b64, iv_b64 = event_msg.event.content.split("?iv=")
+                        iv = base64.decodebytes(iv_b64.encode("utf-8"))
+                        enc_text = base64.decodebytes(enc_text_b64.encode("utf-8"))
+                        # print("decrypt iv: ", iv)
+                        dec_text = aes.decrypt(iv, enc_text)
+                        # print(f"From {event_msg.event.public_key[:5]}...: {dec_text}")
+                        if callback_func:
+                            callback_func(event_msg.event, dec_text)
+                    except:
+                        pass
+                # else:
+                    # print(f"\nFrom {event_msg.event.public_key[:5]}...: {event_msg.event.content}")
+                break
+            time.sleep(0.1)
+
+    async def subscribe(self):
+        while True:
+            while self.relay_manager.message_pool.has_events():
+                event_msg = self.relay_manager.message_pool.get_event()
+                print(event_msg.event.content)
+                break
+            time.sleep(0.1)
+

--- a/nostr/client/client.py
+++ b/nostr/client/client.py
@@ -29,17 +29,18 @@ class NostrClient:
     private_key: PrivateKey
     public_key: PublicKey
 
-    def __init__(self, privatekey_hex: str = "", relays: List[str] = []):
+    def __init__(self, privatekey_hex: str = "", relays: List[str] = [], connect=True):
         self.generate_keys(privatekey_hex)
 
         if len(relays):
             self.relays = relays
 
-        for relay in self.relays:
-            self.relay_manager.add_relay(relay)
-        self.relay_manager.open_connections(
-            {"cert_reqs": ssl.CERT_NONE}
-        )  # NOTE: This disables ssl certificate verification
+        if connect:
+            for relay in self.relays:
+                self.relay_manager.add_relay(relay)
+            self.relay_manager.open_connections(
+                {"cert_reqs": ssl.CERT_NONE}
+            )  # NOTE: This disables ssl certificate verification
 
     def close(self):
         self.relay_manager.close_connections()

--- a/nostr/client/client.py
+++ b/nostr/client/client.py
@@ -48,8 +48,10 @@ class NostrClient:
         pk = bytes.fromhex(privatekey_hex) if privatekey_hex else None
         self.private_key = PrivateKey(pk)
         self.public_key = self.private_key.public_key
-        print(f"Private key: {self.private_key.bech32()} ({self.private_key.hex()})")
-        print(f"Public key: {self.public_key.bech32()} ({self.public_key.hex()})")
+        print(
+            f"Nostr private key: {self.private_key.hex()} ({self.private_key.bech32()})"
+        )
+        print(f"Nostr public key: {self.public_key.hex()} ({self.public_key.bech32()})")
 
     def post(self, message: str):
         event = Event(self.public_key.hex(), message, kind=EventKind.TEXT_NOTE)

--- a/nostr/client/client.py
+++ b/nostr/client/client.py
@@ -3,17 +3,17 @@ import ssl
 import time
 import json
 import os
-import base64 
+import base64
 
-from nostr.event import Event
-from nostr.relay_manager import RelayManager
-from nostr.message_type import ClientMessageType
-from nostr.key import PrivateKey, PublicKey
+from ..event import Event
+from ..relay_manager import RelayManager
+from ..message_type import ClientMessageType
+from ..key import PrivateKey, PublicKey
 
-from nostr.filter import Filter, Filters
-from nostr.event import Event, EventKind
-from nostr.relay_manager import RelayManager
-from nostr.message_type import ClientMessageType
+from ..filter import Filter, Filters
+from ..event import Event, EventKind
+from ..relay_manager import RelayManager
+from ..message_type import ClientMessageType
 
 # from aes import AESCipher
 from . import cbc
@@ -84,9 +84,7 @@ class NostrClient:
 
     def dm(self, message: str, to_pubkey: PublicKey):
 
-        shared_secret = self.private_key.compute_shared_secret(
-            to_pubkey.hex()
-        )
+        shared_secret = self.private_key.compute_shared_secret(to_pubkey.hex())
 
         # print("shared secret: ", shared_secret.hex())
         # print("plain text:", message)
@@ -94,7 +92,6 @@ class NostrClient:
         iv, enc_text = aes.encrypt(message)
         # print("encrypt iv: ", iv)
         content = f"{base64.b64encode(enc_text).decode('utf-8')}?iv={base64.b64encode(iv).decode('utf-8')}"
-
 
         event = Event(
             self.public_key.hex(),
@@ -151,7 +148,7 @@ class NostrClient:
                     except:
                         pass
                 # else:
-                    # print(f"\nFrom {event_msg.event.public_key[:5]}...: {event_msg.event.content}")
+                # print(f"\nFrom {event_msg.event.public_key[:5]}...: {event_msg.event.content}")
                 break
             time.sleep(0.1)
 
@@ -162,4 +159,3 @@ class NostrClient:
                 print(event_msg.event.content)
                 break
             time.sleep(0.1)
-

--- a/nostr/client/client.py
+++ b/nostr/client/client.py
@@ -21,9 +21,8 @@ from . import cbc
 
 class NostrClient:
     relays = [
-        # "wss://nostr-pub.wellorder.net"
+        "wss://nostr-pub.wellorder.net",
         "wss://nostr.zebedee.cloud",
-        # "wss://nodestr.fmt.wiz.biz/",
         # "wss://no.str.cr",
     ]  # ["wss://nostr.oxtr.dev"]  # ["wss://relay.nostr.info"] "wss://nostr-pub.wellorder.net"  "ws://91.237.88.218:2700", "wss://nostrrr.bublina.eu.org", ""wss://nostr-relay.freeberty.net"", , "wss://nostr.oxtr.dev", "wss://relay.nostr.info", "wss://nostr-pub.wellorder.net" , "wss://relayer.fiatjaf.com", "wss://nodestr.fmt.wiz.biz/", "wss://no.str.cr"
     relay_manager = RelayManager()

--- a/nostr/event.py
+++ b/nostr/event.py
@@ -36,7 +36,7 @@ class Event():
     @staticmethod
     def serialize(public_key: str, created_at: int, kind: int, tags: "list[list[str]]", content: str) -> bytes:
         data = [0, public_key, created_at, kind, tags, content]
-        data_str = json.dumps(data, separators=(',', ':'))
+        data_str = json.dumps(data, separators=(',', ':'), ensure_ascii=False)
         return data_str.encode()
 
     @staticmethod

--- a/nostr/filter.py
+++ b/nostr/filter.py
@@ -1,16 +1,18 @@
 from collections import UserList
 from .event import Event
 
+
 class Filter:
     def __init__(
-            self, 
-            ids: "list[str]"=None, 
-            kinds: "list[int]"=None, 
-            authors: "list[str]"=None, 
-            since: int=None, 
-            until: int=None, 
-            tags: "dict[str, list[str]]"=None,
-            limit: int=None) -> None:
+        self,
+        ids: "list[str]" = None,
+        kinds: "list[int]" = None,
+        authors: "list[str]" = None,
+        since: int = None,
+        until: int = None,
+        tags: "dict[str, list[str]]" = None,
+        limit: int = None,
+    ) -> None:
         self.IDs = ids
         self.kinds = kinds
         self.authors = authors
@@ -33,21 +35,21 @@ class Filter:
         if self.tags != None and len(event.tags) == 0:
             return False
         if self.tags != None:
-            e_tag_identifiers = [e_tag[0] for e_tag in event.tags] 
+            e_tag_identifiers = [e_tag[0] for e_tag in event.tags]
             for f_tag, f_tag_values in self.tags.items():
                 if f_tag[1:] not in e_tag_identifiers:
                     return False
                 for e_tag in event.tags:
                     if e_tag[1] not in f_tag_values:
                         return False
-        
+
         return True
 
     def to_json_object(self) -> dict:
         res = {}
         if self.IDs != None:
             res["ids"] = self.IDs
-        if self.kinds != None:   
+        if self.kinds != None:
             res["kinds"] = self.kinds
         if self.authors != None:
             res["authors"] = self.authors
@@ -62,9 +64,10 @@ class Filter:
             res["limit"] = self.limit
 
         return res
-                
+
+
 class Filters(UserList):
-    def __init__(self, initlist: "list[Filter]"=[]) -> None:
+    def __init__(self, initlist: "list[Filter]" = []) -> None:
         super().__init__(initlist)
         self.data: "list[Filter]"
 
@@ -76,4 +79,3 @@ class Filters(UserList):
 
     def to_json_array(self) -> list:
         return [filter.to_json_object() for filter in self.data]
-        

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,259 @@
+[[package]]
+name = "black"
+version = "22.12.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+
+[[package]]
+name = "importlib-metadata"
+version = "5.2.0"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+perf = ["ipython"]
+testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pathspec"
+version = "0.10.3"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.6.0"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.4)"]
+test = ["appdirs (==1.4.4)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+
+[[package]]
+name = "pycryptodomex"
+version = "3.16.0"
+description = "Cryptographic library for Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "typed-ast"
+version = "1.5.4"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "typing-extensions"
+version = "4.4.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "websocket-client"
+version = "1.3.3"
+description = "WebSocket client for Python with low level API options"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["Sphinx (>=3.4)", "sphinx-rtd-theme (>=0.5)"]
+optional = ["python-socks", "wsaccel"]
+test = ["websockets"]
+
+[[package]]
+name = "zipp"
+version = "3.11.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.7"
+content-hash = "b4819f5f4403092e6aafe15d38b9a0850eff2c7b5f9417b2cd0ad5b91c913bcd"
+
+[metadata.files]
+black = [
+    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
+    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
+    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
+    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
+    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
+    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
+    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
+    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
+    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
+    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
+    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
+    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
+]
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+colorama = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-5.2.0-py3-none-any.whl", hash = "sha256:0eafa39ba42bf225fc00e67f701d71f85aead9f878569caf13c3724f704b970f"},
+    {file = "importlib_metadata-5.2.0.tar.gz", hash = "sha256:404d48d62bba0b7a77ff9d405efd91501bef2e67ff4ace0bed40a0cf28c3c7cd"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+pathspec = [
+    {file = "pathspec-0.10.3-py3-none-any.whl", hash = "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6"},
+    {file = "pathspec-0.10.3.tar.gz", hash = "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"},
+]
+platformdirs = [
+    {file = "platformdirs-2.6.0-py3-none-any.whl", hash = "sha256:1a89a12377800c81983db6be069ec068eee989748799b946cce2a6e80dcc54ca"},
+    {file = "platformdirs-2.6.0.tar.gz", hash = "sha256:b46ffafa316e6b83b47489d240ce17173f123a9b9c83282141c3daf26ad9ac2e"},
+]
+pycryptodomex = [
+    {file = "pycryptodomex-3.16.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b3d04c00d777c36972b539fb79958790126847d84ec0129fce1efef250bfe3ce"},
+    {file = "pycryptodomex-3.16.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:e5a670919076b71522c7d567a9043f66f14b202414a63c3a078b5831ae342c03"},
+    {file = "pycryptodomex-3.16.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:ce338a9703f54b2305a408fc9890eb966b727ce72b69f225898bb4e9d9ed3f1f"},
+    {file = "pycryptodomex-3.16.0-cp27-cp27m-manylinux2014_aarch64.whl", hash = "sha256:a1c0ae7123448ecb034c75c713189cb00ebe2d415b11682865b6c54d200d9c93"},
+    {file = "pycryptodomex-3.16.0-cp27-cp27m-win32.whl", hash = "sha256:8851585ff19871e5d69e1790f4ca5f6fd1699d6b8b14413b472a4c0dbc7ea780"},
+    {file = "pycryptodomex-3.16.0-cp27-cp27m-win_amd64.whl", hash = "sha256:8dd2d9e3c617d0712ed781a77efd84ea579e76c5f9b2a4bc0b684ebeddf868b2"},
+    {file = "pycryptodomex-3.16.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:2ad9bb86b355b6104796567dd44c215b3dc953ef2fae5e0bdfb8516731df92cf"},
+    {file = "pycryptodomex-3.16.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:e25a2f5667d91795f9417cb856f6df724ccdb0cdd5cbadb212ee9bf43946e9f8"},
+    {file = "pycryptodomex-3.16.0-cp27-cp27mu-manylinux2014_aarch64.whl", hash = "sha256:b0789a8490114a2936ed77c87792cfe77582c829cb43a6d86ede0f9624ba8aa3"},
+    {file = "pycryptodomex-3.16.0-cp35-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0da835af786fdd1c9930994c78b23e88d816dc3f99aa977284a21bbc26d19735"},
+    {file = "pycryptodomex-3.16.0-cp35-abi3-manylinux2014_aarch64.whl", hash = "sha256:22aed0868622d95179217c298e37ed7410025c7b29dac236d3230617d1e4ed56"},
+    {file = "pycryptodomex-3.16.0-cp35-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1619087fb5b31510b0b0b058a54f001a5ffd91e6ffee220d9913064519c6a69d"},
+    {file = "pycryptodomex-3.16.0-cp35-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:70288d9bfe16b2fd0d20b6c365db614428f1bcde7b20d56e74cf88ade905d9eb"},
+    {file = "pycryptodomex-3.16.0-cp35-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7993d26dae4d83b8f4ce605bb0aecb8bee330bb3c95475ef06f3694403621e71"},
+    {file = "pycryptodomex-3.16.0-cp35-abi3-musllinux_1_1_i686.whl", hash = "sha256:1cda60207be8c1cf0b84b9138f9e3ca29335013d2b690774a5e94678ff29659a"},
+    {file = "pycryptodomex-3.16.0-cp35-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:04610536921c1ec7adba158ef570348550c9f3a40bc24be9f8da2ef7ab387981"},
+    {file = "pycryptodomex-3.16.0-cp35-abi3-win32.whl", hash = "sha256:daa67f5ebb6fbf1ee9c90decaa06ca7fc88a548864e5e484d52b0920a57fe8a5"},
+    {file = "pycryptodomex-3.16.0-cp35-abi3-win_amd64.whl", hash = "sha256:231dc8008cbdd1ae0e34645d4523da2dbc7a88c325f0d4a59635a86ee25b41dd"},
+    {file = "pycryptodomex-3.16.0-pp27-pypy_73-macosx_10_9_x86_64.whl", hash = "sha256:4dbbe18cc232b5980c7633972ae5417d0df76fe89e7db246eefd17ef4d8e6d7a"},
+    {file = "pycryptodomex-3.16.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:893f8a97d533c66cc3a56e60dd3ed40a3494ddb4aafa7e026429a08772f8a849"},
+    {file = "pycryptodomex-3.16.0-pp27-pypy_73-win32.whl", hash = "sha256:6a465e4f856d2a4f2a311807030c89166529ccf7ccc65bef398de045d49144b6"},
+    {file = "pycryptodomex-3.16.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ba57ac7861fd2c837cdb33daf822f2a052ff57dd769a2107807f52a36d0e8d38"},
+    {file = "pycryptodomex-3.16.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f2b971a7b877348a27dcfd0e772a0343fb818df00b74078e91c008632284137d"},
+    {file = "pycryptodomex-3.16.0-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e2453162f473c1eae4826eb10cd7bce19b5facac86d17fb5f29a570fde145abd"},
+    {file = "pycryptodomex-3.16.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:0ba28aa97cdd3ff5ed1a4f2b7f5cd04e721166bd75bd2b929e2734433882b583"},
+    {file = "pycryptodomex-3.16.0.tar.gz", hash = "sha256:e9ba9d8ed638733c9e95664470b71d624a6def149e2db6cc52c1aca5a6a2df1d"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+typed-ast = [
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
+    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
+    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
+    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
+    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+]
+websocket-client = [
+    {file = "websocket-client-1.3.3.tar.gz", hash = "sha256:d58c5f284d6a9bf8379dab423259fe8f85b70d5fa5d2916d5791a84594b122b1"},
+    {file = "websocket_client-1.3.3-py3-none-any.whl", hash = "sha256:5d55652dc1d0b3c734f044337d929aaf83f4f9138816ec680c1aefefb4dc4877"},
+]
+zipp = [
+    {file = "zipp-3.11.0-py3-none-any.whl", hash = "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa"},
+    {file = "zipp-3.11.0.tar.gz", hash = "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "python-nostr"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+pycryptodomex = "^3.16.0"
+websocket-client = "1.3.3"
+
+
+[tool.poetry.group.dev.dependencies]
+black = {version = "^22.12.0", allow-prereleases = true}
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR adds tracking for the conenction state of a Relay. 


In particular, when using multiple ralays of which some may be faulty and/or just slow, the method `Relay.publish` would try to publish independent of the connection state and raise an `websocket._exceptions.WebSocketConnectionClosedException: Connection is already closed.` Exception. 

This means that all publishing attempts on other relays after the faulty one would obviously also fail.

In this PR, I introduce a series of new states for the `Relay` class: 

- `Relay.connected` tracks whether we are connected to the Relay.
- `Relay.reconnect` determines whether we should attempt to reconnect on a dropped connection.
- `Relay.error_counter` counts the number of errors received from a relay.
- `Relay.error_threshold` decides how often we want to attempt to reconnect.
- `Relay.ssl_options` stores the SSL options that we need for a reconnect.

The placing of these methods might be a bit too high-level. I'm open for discussion. It could also be moved to `RelayManager` which would mean that 

- We would need to be a lot more callbacks from `Relay` to the `RelayManager` (for errors, connects, disconnects, ...)
- We would introduce these lower-level things there.

It feels to me that this is better suited for `Relay` since it really only matters for one specific relay.

If you think this is out of place, feel free to close the PR. I'm using this now in a [fork](https://github.com/callebtc/python-nostr) for the [Cashu](https://github.com/cashubtc/cashu) client.