### PR TITLE
Track connection state, reconnect on error, outgoing message queues

### DIFF
--- a/nostr/key.py
+++ b/nostr/key.py
@@ -12,7 +12,7 @@ from . import bech32
 
 
 class PublicKey:
-    def __init__(self, raw_bytes: bytes = None) -> None:
+    def __init__(self, raw_bytes: bytes=None) -> None:
         self.raw_bytes = raw_bytes
 
     def bech32(self) -> str:
@@ -28,14 +28,14 @@ class PublicKey:
 
     @classmethod
     def from_npub(cls, npub: str):
-        """Load a PublicKey from its bech32/npub form"""
+        """ Load a PublicKey from its bech32/npub form """
         hrp, data, spec = bech32.bech32_decode(npub)
         raw_public_key = bech32.convertbits(data, 5, 8)[:-1]
         return cls(bytes(raw_public_key))
 
 
 class PrivateKey:
-    def __init__(self, raw_secret: bytes = None) -> None:
+    def __init__(self, raw_secret: bytes=None) -> None:
         if not raw_secret is None:
             self.raw_secret = raw_secret
         else:
@@ -46,7 +46,7 @@ class PrivateKey:
 
     @classmethod
     def from_nsec(cls, nsec: str):
-        """Load a PrivateKey from its bech32/nsec form"""
+        """ Load a PrivateKey from its bech32/nsec form """
         hrp, data, spec = bech32.bech32_decode(nsec)
         raw_secret = bech32.convertbits(data, 5, 8)[:-1]
         return cls(bytes(raw_secret))
@@ -71,28 +71,22 @@ class PrivateKey:
         padded_data = padder.update(message.encode()) + padder.finalize()
 
         iv = secrets.token_bytes(16)
-        cipher = Cipher(
-            algorithms.AES(self.compute_shared_secret(public_key_hex)), modes.CBC(iv)
-        )
+        cipher = Cipher(algorithms.AES(self.compute_shared_secret(public_key_hex)), modes.CBC(iv))
 
         encryptor = cipher.encryptor()
         encrypted_message = encryptor.update(padded_data) + encryptor.finalize()
 
         return f"{base64.b64encode(encrypted_message).decode()}?iv={base64.b64encode(iv).decode()}"
-
+    
     def encrypt_dm(self, dm: EncryptedDirectMessage) -> None:
-        dm.content = self.encrypt_message(
-            message=dm.cleartext_content, public_key_hex=dm.recipient_pubkey
-        )
+        dm.content = self.encrypt_message(message=dm.cleartext_content, public_key_hex=dm.recipient_pubkey)
 
     def decrypt_message(self, encoded_message: str, public_key_hex: str) -> str:
-        encoded_data = encoded_message.split("?iv=")
+        encoded_data = encoded_message.split('?iv=')
         encoded_content, encoded_iv = encoded_data[0], encoded_data[1]
 
         iv = base64.b64decode(encoded_iv)
-        cipher = Cipher(
-            algorithms.AES(self.compute_shared_secret(public_key_hex)), modes.CBC(iv)
-        )
+        cipher = Cipher(algorithms.AES(self.compute_shared_secret(public_key_hex)), modes.CBC(iv))
         encrypted_content = base64.b64decode(encoded_content)
 
         decryptor = cipher.decryptor()
@@ -116,9 +110,7 @@ class PrivateKey:
         event.signature = self.sign_message_hash(bytes.fromhex(event.id))
 
     def sign_delegation(self, delegation: Delegation) -> None:
-        delegation.signature = self.sign_message_hash(
-            sha256(delegation.delegation_token.encode()).digest()
-        )
+        delegation.signature = self.sign_message_hash(sha256(delegation.delegation_token.encode()).digest())
 
     def __eq__(self, other):
         return self.raw_secret == other.raw_secret
@@ -130,12 +122,9 @@ def mine_vanity_key(prefix: str = None, suffix: str = None) -> PrivateKey:
 
     while True:
         sk = PrivateKey()
-        if (
-            prefix is not None
-            and not sk.public_key.bech32()[5 : 5 + len(prefix)] == prefix
-        ):
+        if prefix is not None and not sk.public_key.bech32()[5:5+len(prefix)] == prefix:
             continue
-        if suffix is not None and not sk.public_key.bech32()[-len(suffix) :] == suffix:
+        if suffix is not None and not sk.public_key.bech32()[-len(suffix):] == suffix:
             continue
         break
 
@@ -143,11 +132,7 @@ def mine_vanity_key(prefix: str = None, suffix: str = None) -> PrivateKey:
 
 
 ffi = FFI()
-
-
-@ffi.callback(
-    "int (unsigned char *, const unsigned char *, const unsigned char *, void *)"
-)
+@ffi.callback("int (unsigned char *, const unsigned char *, const unsigned char *, void *)")
 def copy_x(output, x32, y32, data):
     ffi.memmove(output, x32, 32)
     return 1

--- a/nostr/key.py
+++ b/nostr/key.py
@@ -12,7 +12,7 @@ from . import bech32
 
 
 class PublicKey:
-    def __init__(self, raw_bytes: bytes) -> None:
+    def __init__(self, raw_bytes: bytes = None) -> None:
         self.raw_bytes = raw_bytes
 
     def bech32(self) -> str:
@@ -28,14 +28,14 @@ class PublicKey:
 
     @classmethod
     def from_npub(cls, npub: str):
-        """ Load a PublicKey from its bech32/npub form """
+        """Load a PublicKey from its bech32/npub form"""
         hrp, data, spec = bech32.bech32_decode(npub)
         raw_public_key = bech32.convertbits(data, 5, 8)[:-1]
         return cls(bytes(raw_public_key))
 
 
 class PrivateKey:
-    def __init__(self, raw_secret: bytes=None) -> None:
+    def __init__(self, raw_secret: bytes = None) -> None:
         if not raw_secret is None:
             self.raw_secret = raw_secret
         else:
@@ -46,7 +46,7 @@ class PrivateKey:
 
     @classmethod
     def from_nsec(cls, nsec: str):
-        """ Load a PrivateKey from its bech32/nsec form """
+        """Load a PrivateKey from its bech32/nsec form"""
         hrp, data, spec = bech32.bech32_decode(nsec)
         raw_secret = bech32.convertbits(data, 5, 8)[:-1]
         return cls(bytes(raw_secret))
@@ -71,22 +71,28 @@ class PrivateKey:
         padded_data = padder.update(message.encode()) + padder.finalize()
 
         iv = secrets.token_bytes(16)
-        cipher = Cipher(algorithms.AES(self.compute_shared_secret(public_key_hex)), modes.CBC(iv))
+        cipher = Cipher(
+            algorithms.AES(self.compute_shared_secret(public_key_hex)), modes.CBC(iv)
+        )
 
         encryptor = cipher.encryptor()
         encrypted_message = encryptor.update(padded_data) + encryptor.finalize()
 
         return f"{base64.b64encode(encrypted_message).decode()}?iv={base64.b64encode(iv).decode()}"
-    
+
     def encrypt_dm(self, dm: EncryptedDirectMessage) -> None:
-        dm.content = self.encrypt_message(message=dm.cleartext_content, public_key_hex=dm.recipient_pubkey)
+        dm.content = self.encrypt_message(
+            message=dm.cleartext_content, public_key_hex=dm.recipient_pubkey
+        )
 
     def decrypt_message(self, encoded_message: str, public_key_hex: str) -> str:
-        encoded_data = encoded_message.split('?iv=')
+        encoded_data = encoded_message.split("?iv=")
         encoded_content, encoded_iv = encoded_data[0], encoded_data[1]
 
         iv = base64.b64decode(encoded_iv)
-        cipher = Cipher(algorithms.AES(self.compute_shared_secret(public_key_hex)), modes.CBC(iv))
+        cipher = Cipher(
+            algorithms.AES(self.compute_shared_secret(public_key_hex)), modes.CBC(iv)
+        )
         encrypted_content = base64.b64decode(encoded_content)
 
         decryptor = cipher.decryptor()
@@ -110,7 +116,9 @@ class PrivateKey:
         event.signature = self.sign_message_hash(bytes.fromhex(event.id))
 
     def sign_delegation(self, delegation: Delegation) -> None:
-        delegation.signature = self.sign_message_hash(sha256(delegation.delegation_token.encode()).digest())
+        delegation.signature = self.sign_message_hash(
+            sha256(delegation.delegation_token.encode()).digest()
+        )
 
     def __eq__(self, other):
         return self.raw_secret == other.raw_secret
@@ -122,9 +130,12 @@ def mine_vanity_key(prefix: str = None, suffix: str = None) -> PrivateKey:
 
     while True:
         sk = PrivateKey()
-        if prefix is not None and not sk.public_key.bech32()[5:5+len(prefix)] == prefix:
+        if (
+            prefix is not None
+            and not sk.public_key.bech32()[5 : 5 + len(prefix)] == prefix
+        ):
             continue
-        if suffix is not None and not sk.public_key.bech32()[-len(suffix):] == suffix:
+        if suffix is not None and not sk.public_key.bech32()[-len(suffix) :] == suffix:
             continue
         break
 
@@ -132,7 +143,11 @@ def mine_vanity_key(prefix: str = None, suffix: str = None) -> PrivateKey:
 
 
 ffi = FFI()
-@ffi.callback("int (unsigned char *, const unsigned char *, const unsigned char *, void *)")
+
+
+@ffi.callback(
+    "int (unsigned char *, const unsigned char *, const unsigned char *, void *)"
+)
 def copy_x(output, x32, y32, data):
     ffi.memmove(output, x32, 32)
     return 1

--- a/nostr/relay.py
+++ b/nostr/relay.py
@@ -1,4 +1,5 @@
 import json
+import time
 from threading import Lock
 from websocket import WebSocketApp
 from .event import Event
@@ -7,44 +8,62 @@ from .message_pool import MessagePool
 from .message_type import RelayMessageType
 from .subscription import Subscription
 
+
 class RelayPolicy:
-    def __init__(self, should_read: bool=True, should_write: bool=True) -> None:
+    def __init__(self, should_read: bool = True, should_write: bool = True) -> None:
         self.should_read = should_read
         self.should_write = should_write
 
     def to_json_object(self) -> dict[str, bool]:
-        return { 
-            "read": self.should_read, 
-            "write": self.should_write
-        }
+        return {"read": self.should_read, "write": self.should_write}
+
 
 class Relay:
     def __init__(
-            self, 
-            url: str, 
-            policy: RelayPolicy, 
-            message_pool: MessagePool,
-            subscriptions: dict[str, Subscription]={}) -> None:
+        self,
+        url: str,
+        policy: RelayPolicy,
+        message_pool: MessagePool,
+        subscriptions: dict[str, Subscription] = {},
+    ) -> None:
         self.url = url
         self.policy = policy
         self.message_pool = message_pool
         self.subscriptions = subscriptions
+        self.connected: bool = False
+        self.reconnect: bool = True
+        self.error_counter: int = 0
+        self.error_threshold: int = 0
+        self.ssl_options: dict = {}
         self.lock = Lock()
         self.ws = WebSocketApp(
             url,
             on_open=self._on_open,
             on_message=self._on_message,
             on_error=self._on_error,
-            on_close=self._on_close)
+            on_close=self._on_close,
+        )
 
-    def connect(self, ssl_options: dict=None):
-        self.ws.run_forever(sslopt=ssl_options)
+    def connect(self, ssl_options: dict = {}):
+        self.ssl_options = ssl_options
+        self.ws.run_forever(sslopt=self.ssl_options)
 
     def close(self):
         self.ws.close()
 
+    def check_reconnect(self):
+        try:
+            self.close()
+        except:
+            pass
+        self.connected = False
+        if self.reconnect:
+            time.sleep(1)
+            self.connect(self.ssl_options)
+
     def publish(self, message: str):
-        self.ws.send(message)
+        if self.connected:
+            self.ws.send(message)
 
     def add_subscription(self, id, filters: Filters):
         with self.lock:
@@ -63,25 +82,36 @@ class Relay:
         return {
             "url": self.url,
             "policy": self.policy.to_json_object(),
-            "subscriptions": [subscription.to_json_object() for subscription in self.subscriptions.values()]
+            "subscriptions": [
+                subscription.to_json_object()
+                for subscription in self.subscriptions.values()
+            ],
         }
 
     def _on_open(self, class_obj):
+        self.connected = True
         pass
 
     def _on_close(self, class_obj, status_code, message):
+        self.connected = False
+        self.check_reconnect()
         pass
 
     def _on_message(self, class_obj, message: str):
         if self._is_valid_message(message):
             self.message_pool.add_message(message, self.url)
-    
+
     def _on_error(self, class_obj, error):
-        pass
+        self.connected = False
+        self.error_counter += 1
+        if self.error_threshold and self.error_counter > self.error_threshold:
+            pass
+        else:
+            self.check_reconnect()
 
     def _is_valid_message(self, message: str) -> bool:
         message = message.strip("\n")
-        if not message or message[0] != '[' or message[-1] != ']':
+        if not message or message[0] != "[" or message[-1] != "]":
             return False
 
         message_json = json.loads(message)
@@ -91,21 +121,29 @@ class Relay:
         if message_type == RelayMessageType.EVENT:
             if not len(message_json) == 3:
                 return False
-            
+
             subscription_id = message_json[1]
             with self.lock:
                 if subscription_id not in self.subscriptions:
                     return False
 
             e = message_json[2]
-            event = Event(e['pubkey'], e['content'], e['created_at'], e['kind'], e['tags'], e['id'], e['sig'])
+            event = Event(
+                e["pubkey"],
+                e["content"],
+                e["created_at"],
+                e["kind"],
+                e["tags"],
+                e["id"],
+                e["sig"],
+            )
             if not event.verify():
                 return False
 
             with self.lock:
                 subscription = self.subscriptions[subscription_id]
 
-            if not subscription.filters.match(event):
+            if subscription.filters and not subscription.filters.match(event):
                 return False
 
         return True

--- a/nostr/relay.py
+++ b/nostr/relay.py
@@ -94,7 +94,6 @@ class Relay:
 
     def _on_close(self, class_obj, status_code, message):
         self.connected = False
-        self.check_reconnect()
         pass
 
     def _on_message(self, class_obj, message: str):

--- a/nostr/relay.py
+++ b/nostr/relay.py
@@ -35,6 +35,7 @@ class Relay:
         self.error_counter: int = 0
         self.error_threshold: int = 0
         self.ssl_options: dict = {}
+        self.proxy: dict = {}
         self.lock = Lock()
         self.ws = WebSocketApp(
             url,
@@ -44,13 +45,14 @@ class Relay:
             on_close=self._on_close,
         )
 
-    def connect(self, ssl_options: dict=None, proxy: dict=None):
+    def connect(self, ssl_options: dict = None, proxy: dict = None):
         self.ssl_options = ssl_options
+        self.proxy = proxy
         self.ws.run_forever(
             sslopt=ssl_options,
-            http_proxy_host=None if proxy is None else proxy.get('host'), 
-            http_proxy_port=None if proxy is None else proxy.get('port'),
-            proxy_type=None if proxy is None else proxy.get('type')
+            http_proxy_host=None if proxy is None else proxy.get("host"),
+            http_proxy_port=None if proxy is None else proxy.get("port"),
+            proxy_type=None if proxy is None else proxy.get("type"),
         )
 
     def close(self):
@@ -64,7 +66,7 @@ class Relay:
         self.connected = False
         if self.reconnect:
             time.sleep(1)
-            self.connect(self.ssl_options)
+            self.connect(self.ssl_options, self.proxy)
 
     def publish(self, message: str):
         if self.connected:

--- a/nostr/relay_manager.py
+++ b/nostr/relay_manager.py
@@ -42,6 +42,11 @@ class RelayManager:
                 args=(ssl_options, proxy),
                 name=f"{relay.url}-thread"
             ).start()
+            
+            threading.Thread(
+                target=relay.queue_worker,
+                name=f"{relay.url}-queue",
+            ).start()
 
     def close_connections(self):
         for relay in self.relays.values():


### PR DESCRIPTION
This PR adds tracking for the conenction state of a Relay. 


In particular, when using multiple ralays of which some may be faulty and/or just slow, the method `Relay.publish` would try to publish independent of the connection state and raise `WebSocketConnectionClosedException: Connection is already closed.` 

This means that all publishing attempts on other relays after the faulty one would obviously also fail.

### Changes to `Relay`

#### New or changed attributes

In this PR, I introduce a series of new states for the `Relay` class: 

- `Relay.connected` tracks whether we are connected to the Relay.
- `Relay.reconnect` determines whether we should attempt to reconnect on a dropped connection.
- `Relay.error_counter` counts the number of errors received from a relay.
- `Relay.error_threshold` decides how often we want to attempt to reconnect on an error.
- `Relay.ssl_options` stores the SSL options that we need for a reconnect.

#### New or changed methods

- `Relay.check_reconnect` is called to check whether conditions for reconnect are met
- `Relay._on_error` increments the `error_counter` and calls `check_reconnect` if it is below the `error_threshold`

### Message `Queue`
- `Relay` has a `queue` now which will publish messages only if its state is `connected`.
- The queue worker is called in the `RelayManager` in a separate thread.

### Notes

The placing of these methods might be a bit too low-level for your taste. I'm open for suggestions. It could also be moved to `RelayManager` which would mean that 

- We would need to be a lot more callbacks from `Relay` to the `RelayManager` (for errors, connects, disconnects, ...)
- We would introduce these lower-level things there.

It feels to me that this is better suited for `Relay` since it really only matters for one specific relay.

If you think this is out of place, feel free to close the PR. I'm using this now in a [fork](https://github.com/callebtc/python-nostr) for the [Cashu](https://github.com/cashubtc/cashu) client.