### PR TITLE
remove default tags list from Event class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ nostr.egg-info/
 dist/
 nostr/_version.py
 .DS_Store
+.python-version

--- a/nostr/event.py
+++ b/nostr/event.py
@@ -23,7 +23,7 @@ class Event():
             content: str, 
             created_at: int = None, 
             kind: int=EventKind.TEXT_NOTE, 
-            tags: "list[list[str]]"=[], 
+            tags: "list[list[str]]" = None, 
             id: str=None, 
             signature: str=None) -> None:
         if not isinstance(content, str):
@@ -33,7 +33,7 @@ class Event():
         self.content = content
         self.created_at = created_at or int(time.time())
         self.kind = kind
-        self.tags = tags
+        self.tags = tags or []
         self.signature = signature
         self.id = id or Event.compute_id(self.public_key, self.created_at, self.kind, self.tags, self.content)
 


### PR DESCRIPTION
Similar to the issue discovered in #23 . Make default tag list `None` and then assign `self.tags` an empty list if `None`

demo of bug:

```python
from nostr.event import Event
from nostr.key import PrivateKey

# Create two separate events with default tags value

test_event = Event(
    PrivateKey().public_key.hex(),
    "test content"
)

test_event_2 = Event(
    PrivateKey().public_key.hex(),
    "test content 2"
)

# Append a tag to the first event
test_event.tags.append(["p","p tag"])

print(test_event_2.tags)
#out: [["p","p tag"]]