### PR TITLE
Fix: `Event` dataclass update in #39

### DIFF
--- a/nostr/message_pool.py
+++ b/nostr/message_pool.py
@@ -55,7 +55,14 @@ class MessagePool:
         if message_type == RelayMessageType.EVENT:
             subscription_id = message_json[1]
             e = message_json[2]
-            event = Event(e['pubkey'], e['content'], e['created_at'], e['kind'], e['tags'], e['id'], e['sig'])
+            event = Event(
+                e["content"],
+                e["pubkey"],
+                e["created_at"],
+                e["kind"],
+                e["tags"],
+                e["sig"],
+            )
             with self.lock:
                 if not event.id in self._unique_events:
                     self.events.put(EventMessage(event, subscription_id, url))

--- a/nostr/relay.py
+++ b/nostr/relay.py
@@ -103,7 +103,14 @@ class Relay:
                     return False
 
             e = message_json[2]
-            event = Event(e['pubkey'], e['content'], e['created_at'], e['kind'], e['tags'], e['id'], e['sig'])
+            event = Event(
+                e["content"],
+                e["pubkey"],
+                e["created_at"],
+                e["kind"],
+                e["tags"],
+                e["sig"],
+            )
             if not event.verify():
                 return False
 


### PR DESCRIPTION
The last PR #39 with the change to the `Event` dataclass introduced a bunch of initialization problems that are fixed in this PR.

Duplicates parts of https://github.com/jeffthibault/python-nostr/pull/50 but with less changes. 

I suggest merging https://github.com/jeffthibault/python-nostr/pull/50 as well or instead of this PR. 