### PR TITLE
Fix: relative imports

### DIFF
--- a/nostr/event.py
+++ b/nostr/event.py
@@ -6,7 +6,7 @@ from typing import List
 from secp256k1 import PrivateKey, PublicKey
 from hashlib import sha256
 
-from nostr.message_type import ClientMessageType
+from .message_type import ClientMessageType
 
 
 

--- a/nostr/key.py
+++ b/nostr/key.py
@@ -6,8 +6,8 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives import padding
 from hashlib import sha256
 
-from nostr.delegation import Delegation
-from nostr.event import EncryptedDirectMessage, Event, EventKind
+from .delegation import Delegation
+from .event import EncryptedDirectMessage, Event, EventKind
 from . import bech32
 
 


### PR DESCRIPTION
Relative imports are necessary in order to use the code in another project.