### PR TITLE
refactor relay threads

### DIFF
--- a/nostr/relay_manager.py
+++ b/nostr/relay_manager.py
@@ -20,10 +20,19 @@ class RelayException(Exception):
 
 @dataclass
 class RelayManager:
+    connection_monitor_interval_secs: int = 5
+
     def __post_init__(self):
         self.relays: dict[str, Relay] = {}
         self.message_pool: MessagePool = MessagePool()
         self.lock: Lock = Lock()
+
+        threading.Thread(
+            target=self._relay_connection_monitor,
+            name="relay-connection-monitor",
+            daemon=True
+        ).start()
+
 
     def add_relay(
             self, 
@@ -36,19 +45,7 @@ class RelayManager:
 
         with self.lock:
             self.relays[url] = relay
-
-        threading.Thread(
-            target=relay.connect,
-            name=f"{relay.url}-thread"
-        ).start()
-        
-        threading.Thread(
-            target=relay.queue_worker,
-            name=f"{relay.url}-queue",
-            daemon=True
-        ).start()
-
-        time.sleep(1)
+            relay.connect()
 
     def remove_relay(self, url: str):
         with self.lock:
@@ -109,3 +106,12 @@ class RelayManager:
             for relay in self.relays.values():
                 if relay.policy.should_write:
                     relay.publish(event.to_message())
+
+    def _relay_connection_monitor(self):
+        while True:
+            with self.lock:
+                for relay in self.relays.values():
+                    if not relay.is_connected():
+                        relay.connect(True)
+
+            time.sleep(self.connection_monitor_interval_secs)


### PR DESCRIPTION
**Relay class**
- Add thread instantiation to `connect` method
- Add `is_connected` method which checks if the `ws.run_forever` thread is alive. I think this is more reliable because this thread will be torn down on disconnect.
- Various renaming

**Relay Manager**
- Remove thread instantiation from `add_relay` (handled in `relay.connect` now)
- Add `relay_connection_monitor` thread, which periodically (`connection_monitor_interval_secs`) checks if the relays are disconnected and reconnects them if they are.

Note: I felt like reconnection logic belongs in the relay manager as it's job is to manage the relays