### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ time.sleep(1.25) # allow the connections to open
 
 private_key = PrivateKey()
 
-event = Event("Hello Nostr")
+event = Event(private_key.public_key.hex(), "Hello Nostr")
 private_key.sign_event(event)
 
 relay_manager.publish_event(event)


### PR DESCRIPTION
This fix the error I had: `Event.__init__() missing 1 required positional argument: 'content'`

My guess is that other parts of the documentation would need to be updated but I only tested the **Publish to relays** section for now